### PR TITLE
Needs GHC >= 7.8 due to AmbiguousTypes

### DIFF
--- a/kansas-lava.cabal
+++ b/kansas-lava.cabal
@@ -49,7 +49,7 @@ Flag tools
 
 Library
   Build-Depends:
-        base >= 4 && < 5,
+        base >= 4.7 && < 5,
         containers,
         array,
         sized-types >= 0.4.1.1,


### PR DESCRIPTION
I've revised existing versions ( https://hackage.haskell.org/package/kansas-lava-0.2.4.3/revisions/ ). There is no need for a new release unless you want to fix backwards compatibility.
